### PR TITLE
Add photo upload endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -91,3 +91,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem "cloudinary", "~> 1.11"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -43,6 +43,7 @@ GEM
       minitest (~> 5.1)
       tzinfo (~> 1.1)
     arel (9.0.0)
+    aws_cf_signer (0.1.3)
     bcrypt (3.1.12)
     bindex (0.5.0)
     builder (3.2.3)
@@ -52,6 +53,9 @@ GEM
     byebug (10.0.2)
     cancancan (2.3.0)
     choice (0.2.0)
+    cloudinary (1.11.0)
+      aws_cf_signer
+      rest-client
     coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
@@ -73,6 +77,8 @@ GEM
       rails (>= 3.0.4)
       warden
     diff-lcs (1.3)
+    domain_name (0.5.20180417)
+      unf (>= 0.0.5, < 1.0.0)
     dotenv (2.5.0)
     dotenv-rails (2.5.0)
       dotenv (= 2.5.0)
@@ -85,6 +91,8 @@ GEM
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     hashie (3.5.7)
+    http-cookie (1.0.3)
+      domain_name (~> 0.5)
     i18n (1.1.1)
       concurrent-ruby (~> 1.0)
     jbuilder (2.8.0)
@@ -109,6 +117,9 @@ GEM
     marcel (0.3.3)
       mimemagic (~> 0.3.2)
     method_source (0.9.2)
+    mime-types (3.2.2)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2018.0812)
     mimemagic (0.3.2)
     mini_mime (1.0.1)
     mini_portile2 (2.3.0)
@@ -117,6 +128,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.0.0)
     mustermann (1.0.3)
+    netrc (0.11.0)
     nio4r (2.3.1)
     nokogiri (1.8.5)
       mini_portile2 (~> 2.3.0)
@@ -195,6 +207,10 @@ GEM
     responders (2.4.0)
       actionpack (>= 4.2.0, < 5.3)
       railties (>= 4.2.0, < 5.3)
+    rest-client (2.0.2)
+      http-cookie (>= 1.0.2, < 2.0)
+      mime-types (>= 1.16, < 4.0)
+      netrc (~> 0.8)
     rspec-core (3.8.0)
       rspec-support (~> 3.8.0)
     rspec-expectations (3.8.2)
@@ -250,6 +266,9 @@ GEM
       thread_safe (~> 0.1)
     uglifier (4.1.20)
       execjs (>= 0.3.0, < 3)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.5)
     uniform_notifier (1.12.1)
     warden (1.2.8)
       rack (>= 2.0.6)
@@ -269,6 +288,7 @@ DEPENDENCIES
   bullet
   byebug
   cancancan (~> 2.0)
+  cloudinary (~> 1.11)
   coffee-rails (~> 4.2)
   devise
   devise_suspendable
@@ -301,4 +321,4 @@ RUBY VERSION
    ruby 2.5.0p0
 
 BUNDLED WITH
-   1.17.1
+   1.17.2

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,3 +1,5 @@
+
+
 class Api::V1::UsersController < ApplicationController
   # before_action :authenticate_user!, only: [:index]
   skip_before_action :verify_authenticity_token
@@ -65,27 +67,7 @@ class Api::V1::UsersController < ApplicationController
       meeting_options_hash[option.name.to_sym] = true;
     end
 
-    user_info = {email: user[:email],
-                 id: user[:id],
-                 firstName: user[:first_name],
-                 lastName: user[:last_name],
-                 admin: user[:admin], 
-                 superadmin: user[:superadmin], 
-                 public_figure: user[:public_figure], 
-                 is_mentor: user[:is_mentor], 
-                 bio: user[:about], 
-                 photo: user[:photo], 
-                 block_connection_requests: user[:block_connection_requests],
-                 city: user[:city],
-                 training: user[:training],
-                 experience: user[:experience],
-                 website: user[:website],
-                 video: user[:video_link],
-                 meeting_options: user[:meeting_options_hash],
-                 suspended: user[:suspended]
-    }
-
-    render json: user_info
+    render json: serialize_user(user)
   end
 
   def fetch_user_feed
@@ -105,6 +87,20 @@ class Api::V1::UsersController < ApplicationController
     @user.update(user_params)
 
     render 'show.json.jbuilder'
+  end
+
+  def upload_profile_photo
+    head(:forbidden) unless params[:id] == req.headers['id'].to_i
+    head(:bad_request) unless ["image/jpeg", "image/gif", "image/png"].include?(@content_type)
+
+    user = User.find(params[:id])
+    upload = Cloudinary::Uploader.upload(@tempfile,
+      :folder => "profile_photos", :public_id => user.id, :overwrite => true,
+      :resource_type => "image")
+    head(:bad_gateway) unless upload
+    
+    user.update(profile_pic_url: upload.secure_url)
+    render json: serialize_user(user)
   end
 
   def block_connection_requests
@@ -147,8 +143,30 @@ class Api::V1::UsersController < ApplicationController
     AdminMailer.email_all_users(params[:email], params[:subject]).deliver_now
   end
 
-
   private
+
+  def serialize_user(user)
+    return {
+      email: user[:email],
+      id: user[:id],
+      firstName: user[:first_name],
+      lastName: user[:last_name],
+      admin: user[:admin], 
+      superadmin: user[:superadmin], 
+      public_figure: user[:public_figure], 
+      is_mentor: user[:is_mentor], 
+      bio: user[:about], 
+      photo: user[:photo], 
+      block_connection_requests: user[:block_connection_requests],
+      city: user[:city],
+      training: user[:training],
+      experience: user[:experience],
+      website: user[:website],
+      video: user[:video_link],
+      meeting_options: user[:meeting_options_hash],
+      suspended: user[:suspended]
+    }
+  end
 
   def user_params
     params.permit(:email, :password, :first_name, :last_name, :city, :website, :video_link, :gender, :training, :experience, :admin, :photo, :birthDate, :about, :superadmin, :public_figure, :is_mentor, meet_option_users_attributes: [])

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,4 +1,4 @@
-
+require 'cloudinary'
 
 class Api::V1::UsersController < ApplicationController
   # before_action :authenticate_user!, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -48,6 +48,8 @@ Rails.application.routes.draw do
   delete '/api/v1/users/connections/:id', to: 'api/v1/connection_requests#destroy'
   #block incoming connection requests
   post '/api/v1/users/:id', to: 'api/v1/users#block_connection_requests'
+  # upload a photo
+  post '/api/v1/users/:id/photo', to: 'api/v1/users#upload_profile_photo'
 
   #for blocking a user
   post '/api/v1/users/blocks/:id', to: 'api/v1/user_blocks#create' 


### PR DESCRIPTION
We'd like to avoid using Firebase, which at present isn't set up properly on the front end anyway. Using client-side storage for photos likely isn't a good option for us. Thus, we'll want to upload photos on the backend.

This adds an endpoint to upload a photo to Cloudinary. It will require sending a standard POST form request to the `/api/v1/users/:id/photo` endpoint with the file attached. It updates the `photo` field on the user and returns a user object.